### PR TITLE
Let wasmd and osmosis write logs in different files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 target/
 debug.log
 
+# Chain logs
+debug-*.log
+
 # IDEs
 .vscode/
 .idea/

--- a/ci-scripts/osmosis/README.md
+++ b/ci-scripts/osmosis/README.md
@@ -18,7 +18,7 @@ Run the following:
 scripts/osmosis/start.sh
 ```
 
-You get filtered output on the console. If it crashes and you want the full logs, look at `debug.log`.
+You get filtered output on the console. If it crashes and you want the full logs, look at `debug-osmosis.log`.
 
 ## Stopping the blockchain
 

--- a/ci-scripts/osmosis/start.sh
+++ b/ci-scripts/osmosis/start.sh
@@ -25,4 +25,4 @@ docker run --rm \
   --mount type=bind,source="$SCRIPT_DIR/template",target=/template \
   --mount type=volume,source=osmosis_data,target=/root \
   "$REPOSITORY:$VERSION" \
-  2>&1 | tee debug.log | grep 'executed block'
+  2>&1 | tee debug-osmosis.log | grep 'executed block'

--- a/ci-scripts/wasmd/README.md
+++ b/ci-scripts/wasmd/README.md
@@ -18,7 +18,7 @@ Run the following:
 scripts/wasmd/start.sh
 ```
 
-You get filtered output on the console. If it crashes and you want the full logs, look at `debug.log`.
+You get filtered output on the console. If it crashes and you want the full logs, look at `debug-wasmd.log`.
 
 ## Stopping the blockchain
 

--- a/ci-scripts/wasmd/start.sh
+++ b/ci-scripts/wasmd/start.sh
@@ -30,4 +30,4 @@ docker run --rm \
   --mount type=volume,source=wasmd_data,target=/root \
   "$REPOSITORY:$VERSION" \
   /opt/run.sh \
-  2>&1 | tee debug.log | grep 'executed block'
+  2>&1 | tee debug-wasmd.log | grep 'executed block'


### PR DESCRIPTION
otherwise the chains override each other or append to the same file, making it very hard to debug a crash on one chain if the other is still running.